### PR TITLE
Convert base32 encoded hash to upper case

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -94,7 +94,7 @@ func (cli *Cli) Generate(label string, n int) (listOtp []string, err error) {
 		return nil, fmt.Errorf(`%s: %w`, logp, err)
 	}
 
-	secret, err = b32Enc.DecodeString(issuer.Secret)
+	secret, err = b32Enc.DecodeString(strings.ToUpper(issuer.Secret))
 	if err != nil {
 		return nil, fmt.Errorf(`%s: secret is not a valid base32 encoding: %w`, logp, err)
 	}


### PR DESCRIPTION
`add` works with lower case but fails on `gen`. May be better to fix add to convert automatically but that broke a lot of unit tests